### PR TITLE
Improved xpath selector

### DIFF
--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -55,7 +55,7 @@ module Selectivity
           element = if page.driver.class.name =~ /poltergeist/i
                       find('div.selectivity-result-item', text: item)
                     else
-                      find(:xpath, "//div[contains(@class,'selectivity-result-item')][text()='#{item}']")
+                      find(:xpath, ".//div[contains(@class,'selectivity-result-item')][text()='#{item}']")
                     end
 
           if element.visible?

--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -55,7 +55,7 @@ module Selectivity
           element = if page.driver.class.name =~ /poltergeist/i
                       find('div.selectivity-result-item', text: item)
                     else
-                      find(:xpath, "//div[@class='selectivity-result-item'][contains(text(), '#{item}')]")
+                      find(:xpath, "//div[contains(@class,'selectivity-result-item')][text()='#{item}']")
                     end
 
           if element.visible?


### PR DESCRIPTION
The current selector fails to select the default highlighted option, and fails when there are multiple options with the same text, e.g., "active" and "inactive". This selector resolves both problems.
