### PR TITLE
Better finder logic

### DIFF
--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -38,11 +38,10 @@ module Selectivity
 
       def find_selectivity_input(from, options)
         label = first(:xpath, ".//label[contains(., '#{from}')]", options)
-        find(:div, "##{label[:for]}", options)
         unless lable.nil?
           find(:div, "##{label[:for]}", options)
         else
-          first(:xpath, ".//div[contains(., '#{from}')]", options).first('select')
+          first(:xpath, ".//div[contains(., '#{from}')]", options)
         end
       end
 

--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -37,11 +37,10 @@ module Selectivity
       private
 
       def find_selectivity_input(from, options)
-        find(:div, from, options)
-      rescue Capybara::ElementNotFound
-        label = find('label', { text: from }.merge(options))
-
+        label = first(:xpath, "//label[contains(., '#{from}')]", options)
         find(:div, "##{label[:for]}", options)
+      rescue Capybara::ElementNotFound
+        first(:xpath, "//div[contains(., '#{from}')]", options).first('select')
       end
 
       def _selectivity_multiselect?(input)

--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -41,7 +41,7 @@ module Selectivity
         unless lable.nil?
           find(:div, "##{label[:for]}", options)
         else
-          first(:xpath, ".//div[contains(., '#{from}')]", options)
+          first(:xpath, ".//div[contains(., '#{from}')]", options).first('.selectivity-input')
         end
       end
 

--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -37,10 +37,10 @@ module Selectivity
       private
 
       def find_selectivity_input(from, options)
-        label = first(:xpath, "//label[contains(., '#{from}')]", options)
+        label = first(:xpath, ".//label[contains(., '#{from}')]", options)
         find(:div, "##{label[:for]}", options)
       rescue Capybara::ElementNotFound
-        first(:xpath, "//div[contains(., '#{from}')]", options).first('select')
+        first(:xpath, ".//div[contains(., '#{from}')]", options).first('select')
       end
 
       def _selectivity_multiselect?(input)

--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -38,7 +38,7 @@ module Selectivity
 
       def find_selectivity_input(from, options)
         label = first(:xpath, ".//label[contains(., '#{from}')]", options)
-        unless lable.nil?
+        if label
           find(:div, "##{label[:for]}", options)
         else
           first(:xpath, ".//div[contains(., '#{from}')]", options).first('.selectivity-input')

--- a/lib/selectivity/rspec.rb
+++ b/lib/selectivity/rspec.rb
@@ -39,8 +39,11 @@ module Selectivity
       def find_selectivity_input(from, options)
         label = first(:xpath, ".//label[contains(., '#{from}')]", options)
         find(:div, "##{label[:for]}", options)
-      rescue Capybara::ElementNotFound
-        first(:xpath, ".//div[contains(., '#{from}')]", options).first('select')
+        unless lable.nil?
+          find(:div, "##{label[:for]}", options)
+        else
+          first(:xpath, ".//div[contains(., '#{from}')]", options).first('select')
+        end
       end
 
       def _selectivity_multiselect?(input)


### PR DESCRIPTION
This PR updates the `find_selectivity_input` method to first search for the first `label` with the text, then fallback to looking for an enclosing div with a `select` child.
